### PR TITLE
修复 MySQL dbQuery 流结束时可能挂起

### DIFF
--- a/src/db-ops.js
+++ b/src/db-ops.js
@@ -649,6 +649,8 @@ export class DbOpsManager {
           once(() => reject(err));
         });
         stream.on("end", () => once(resolve));
+        // Drain mysql2 ResultsStream so its end event fires even without a consumer.
+        stream.resume();
       });
       await raceDeadline(streamed, {
         signal: opts.signal, timeoutMs: this.dl("op"), label,

--- a/test/db-ops.mjs
+++ b/test/db-ops.mjs
@@ -284,6 +284,7 @@ function makeTimeoutManager(errorProps, suffix) {
         stream: () => {
           const s = new EventEmitter();
           s.destroy = () => {};
+          s.resume = () => {};
           setImmediate(() => {
             const err = new Error(suffix);
             Object.assign(err, errorProps);


### PR DESCRIPTION
### 问题/动机
MySQL ResultsStream 在只监听 end 而没有消费者时可能不会被 drain，导致 dbQuery Promise 不结束并占用连接。v0.3.2 仍可复现。

### 改动点
- 在 MySQL 查询流的 end 监听后调用 `stream.resume()`，确保流被消费并及时结束。
- 为测试 double 补齐 `resume()` 桩。

### 测试证据
- 上游 `npm install` 成功。
- 上游 `npm test`：39 tests passed / 0 failed。
- 复现方式：使用仓库中 dbQuery stream fixture，执行 MySQL 查询后不读取流；修复前 Promise 挂起，修复后正常 resolve。

### 兼容性说明
仅影响 MySQL 流读取生命周期；现有 API、返回值和超时语义不变。无额外环境变量，无 lib bundle 提交。

### 后续提案
危险 DDL 审批链可另行讨论是否纳入上游能力面。