### PR TITLE
增强 SSH 会话可观察性工具

### DIFF
--- a/src/descriptors.js
+++ b/src/descriptors.js
@@ -37,6 +37,8 @@ function def(method, requestSchema, requestType, resultSchema, resultType, optio
 }
 
 export const DESCRIPTORS = [
+  def("listObservableSessions", S.listObservableSessionsRequestSchema, "SshListObservableSessionsRequest", S.listObservableSessionsResultSchema, "SshListObservableSessionsResult"),
+  def("readObservableSession", S.readObservableSessionRequestSchema, "SshReadObservableSessionRequest", S.readObservableSessionResultSchema, "SshReadObservableSessionResult"),
   def("list", S.listRequestSchema, "SshListRequest", S.listResultSchema, "SshListResult"),
   def("connect", S.connectRequestSchema, "SshConnectRequest", S.connectResultSchema, "SshConnectResult"),
   def("profileList", S.profileListRequestSchema, "SshProfileListRequest", S.profileListResultSchema, "SshProfileListResult"),

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,8 @@ const MAX_FILE_READ_BYTES = 4 * 1024 * 1024;
 // Late readers can still see the exit status of the N most recently exited
 // sessions (session tombstones).
 const MAX_EXIT_TOMBSTONES = 64;
+export const SSH_SESSION_READ_DEFAULT_BYTES = 32 * 1024;
+export const SSH_SESSION_READ_MAX_BYTES = 128 * 1024;
 
 const profileRecordSchema = z.object({
   name: z.string(),
@@ -1011,6 +1013,8 @@ export default class SshOpsService extends TypertRemoteService {
     const session = {
       id: sessionId,
       connectionId: request.connectionId,
+      openedAt: new Date().toISOString(),
+      origin: request.origin ?? "plugin-ui",
       cols,
       rows,
       buffer: "",
@@ -1066,6 +1070,35 @@ export default class SshOpsService extends TypertRemoteService {
         alive: true
       }
     };
+  }
+
+  listObservableSessions() {
+    const sessions = [];
+    for (const session of this.sessions.values()) {
+      const connection = this.connections.get(session.connectionId);
+      if (!connection) continue;
+      const bounds = this.terminalOutput(session).readRange(undefined, SSH_SESSION_READ_DEFAULT_BYTES);
+      const item = {
+        sessionId: session.id, connectionId: session.connectionId, host: connection.host, port: connection.port,
+        openedAt: session.openedAt, origin: session.origin, alive: session.exited === null && session.stream !== null,
+        journalStartOffset: bounds.journalStartOffset, journalEndOffset: bounds.journalEndOffset
+      };
+      if (connection.name !== undefined) item.name = connection.name;
+      sessions.push(item);
+    }
+    return { ok: true, value: { sessions } };
+  }
+
+  readObservableSession(request) {
+    const maxBytes = request.maxBytes ?? SSH_SESSION_READ_DEFAULT_BYTES;
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 1024 || maxBytes > SSH_SESSION_READ_MAX_BYTES) {
+      return { ok: false, error: fail("bad-max-bytes", `maxBytes must be between 1024 and ${SSH_SESSION_READ_MAX_BYTES}`) };
+    }
+    const session = this.sessions.get(request.sessionId);
+    if (!session) return { ok: false, error: fail("no-session", `session "${request.sessionId}" does not exist`) };
+    const item = this.terminalOutput(session).readRange(request.after, maxBytes);
+    const safe = redactForModel(item.data);
+    return { ok: true, value: { sessionId: session.id, ...item, data: safe.text, alive: session.exited === null && session.stream !== null, exit: session.exited, redacted: safe.redacted } };
   }
 
   async write(request) {
@@ -2520,7 +2553,7 @@ export default class SshOpsService extends TypertRemoteService {
       return session !== void 0 && session.exited === null && session.stream !== null;
     });
     if (live) return { ok: true, connectionId: selected.connectionId };
-    const opened = await this.openSession({ connectionId: selected.connectionId, cols: 100, rows: 30 });
+    const opened = await this.openSession({ connectionId: selected.connectionId, cols: 100, rows: 30, origin: "agent" });
     if (!opened.ok) return opened;
     return { ok: true, connectionId: selected.connectionId };
   }

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -184,7 +184,8 @@ export const groupDeleteResultSchema = resultSchema(z.object({ deleted: z.boolea
 export const openSessionRequestSchema = z.object({
   connectionId: z.string().min(1),
   cols: z.number().int().min(2).max(500).optional(),
-  rows: z.number().int().min(1).max(200).optional()
+  rows: z.number().int().min(1).max(200).optional(),
+  origin: z.enum(["workbench-ui", "agent", "plugin-ui", "unknown"]).optional()
 });
 
 export const sessionInfoSchema = z.object({
@@ -196,6 +197,14 @@ export const sessionInfoSchema = z.object({
 });
 
 export const openSessionResultSchema = resultSchema(sessionInfoSchema);
+
+export const observableSessionSchema = z.object({
+  sessionId: z.string(), connectionId: z.string(), name: z.string().optional(), host: z.string(), port: z.number(),
+  openedAt: z.string(), origin: z.enum(["workbench-ui", "agent", "plugin-ui", "unknown"]), alive: z.boolean(),
+  journalStartOffset: z.number().int().nonnegative(), journalEndOffset: z.number().int().nonnegative()
+});
+export const listObservableSessionsRequestSchema = z.object({});
+export const listObservableSessionsResultSchema = resultSchema(z.object({ sessions: z.array(observableSessionSchema) }));
 
 // ── write ───────────────────────────────────────────────────────────────────
 
@@ -287,6 +296,16 @@ export const readResultSchema = resultSchema(
     exit: z.union([z.object({ code: z.number(), signal: z.number().optional() }), z.null()])
   })
 );
+
+export const readObservableSessionRequestSchema = z.object({
+  sessionId: z.string().min(1), after: z.number().int().nonnegative().safe().optional(),
+  maxBytes: z.number().int().min(1024).max(131072).optional()
+});
+export const readObservableSessionResultSchema = resultSchema(z.object({
+  sessionId: z.string(), data: z.string(), journalStartOffset: z.number().int().nonnegative(), journalEndOffset: z.number().int().nonnegative(),
+  startOffset: z.number().int().nonnegative(), nextOffset: z.number().int().nonnegative(), cursorClamped: z.boolean(), hasMore: z.boolean(), alive: z.boolean(),
+  exit: z.union([z.object({ code: z.number(), signal: z.number().optional() }), z.null()]), redacted: z.boolean()
+}));
 
 // ── resize ──────────────────────────────────────────────────────────────────
 

--- a/src/terminal-output.js
+++ b/src/terminal-output.js
@@ -19,6 +19,26 @@ export function createTerminalOutput(initial = '', maxBytes = 1024 * 1024) {
       const code = text.charCodeAt(from - start);
       if (code >= 0xdc00 && code <= 0xdfff) from++;
       return { data: text.slice(from - start), startOffset: from, offset: end };
+    },
+    readRange(after, maxBytes) {
+      const start = end - text.length;
+      const bounded = Number.isSafeInteger(maxBytes) ? maxBytes : 32768;
+      let from = Number.isSafeInteger(after) ? Math.max(start, Math.min(end, after)) : start;
+      const cursorClamped = Number.isSafeInteger(after) && after < start;
+      let available = text.slice(from - start);
+      let bytes = Buffer.from(available, 'utf8');
+      if (!Number.isSafeInteger(after) && bytes.length > bounded) {
+        bytes = bytes.subarray(bytes.length - bounded);
+        while (bytes.length > 0 && (bytes[0] & 0xc0) === 0x80) bytes = bytes.subarray(1);
+        available = bytes.toString('utf8');
+        from = end - available.length;
+      } else if (bytes.length > bounded) {
+        bytes = bytes.subarray(0, bounded);
+        while (bytes.length > 0 && (bytes[bytes.length - 1] & 0xc0) === 0x80) bytes = bytes.subarray(0, bytes.length - 1);
+        available = bytes.toString('utf8');
+      }
+      const nextOffset = from + available.length;
+      return { data: available, journalStartOffset: start, journalEndOffset: end, startOffset: from, nextOffset, cursorClamped, hasMore: nextOffset < end };
     }
   };
   journal.append(initial);

--- a/src/tools/ssh-session.js
+++ b/src/tools/ssh-session.js
@@ -7,6 +7,47 @@ import { defineTool } from "@deepseek-ai/dsh-tools";
 
 export function registerSshSessionTools(ctx, service) {
   ctx.tools.register(defineTool({
+    name: "ssh_session_list",
+    description: "List live SSH PTY sessions shared by the SSH panel and agent. Returns metadata only (origin, host, offsets and liveness); never terminal output or credentials.",
+    parameters: {},
+    output: { schema: { type: "object", additionalProperties: false, properties: {
+      sessions: { type: "array", required: true, items: { type: "object", additionalProperties: false, properties: {
+        sessionId: { type: "string", required: true }, connectionId: { type: "string", required: true }, name: { type: "string" }, host: { type: "string", required: true }, port: { type: "integer", required: true }, openedAt: { type: "string", required: true }, origin: { type: "string", required: true }, alive: { type: "boolean", required: true }, journalStartOffset: { type: "integer", required: true }, journalEndOffset: { type: "integer", required: true }
+      } } }
+    } } },
+    async execute() {
+      const result = service.listObservableSessions();
+      if (!result.ok) throw new Error(`ssh_session_list failed: ${result.error.message}`);
+      return result.value;
+    }
+  }));
+
+  ctx.tools.register(defineTool({
+    name: "ssh_session_read",
+    description: "Read a bounded range of a shared SSH PTY journal after user approval. Defaults to the latest 32 KiB and never exceeds 128 KiB; this is read-only and does not consume other readers.",
+    parameters: {
+      session_id: { type: "string", required: true },
+      after: { type: "integer", description: "Optional journal cursor, clamped when older than retention." },
+      max_bytes: { type: "integer", description: "Optional byte window, 1024..131072; defaults to 32768." }
+    },
+    output: { schema: { type: "object", additionalProperties: false, properties: {
+      sessionId: { type: "string", required: true }, data: { type: "string", required: true }, journalStartOffset: { type: "integer", required: true }, journalEndOffset: { type: "integer", required: true }, startOffset: { type: "integer", required: true }, nextOffset: { type: "integer", required: true }, cursorClamped: { type: "boolean", required: true }, hasMore: { type: "boolean", required: true }, alive: { type: "boolean", required: true }, exit: { oneOf: [{ type: "object", additionalProperties: false }, { type: "null" }], required: true }, redacted: { type: "boolean", required: true }
+    } } },
+    async execute(args) {
+      const result = service.readObservableSession({ sessionId: args.session_id, after: args.after, maxBytes: args.max_bytes });
+      if (!result.ok) throw new Error(`ssh_session_read failed: ${result.error.message}`);
+      return result.value;
+    }
+  }));
+
+  if (typeof ctx.on === "function") ctx.on("tools/pre-execute", (...args) => {
+    const exec = args[0];
+    const next = args[1];
+    if (exec?.name !== "ssh_session_read") return typeof next === "function" ? next() : undefined;
+    return { kind: "ask", reason: "Agent 请求读取当前 SSH 终端内容，终端可能包含命令结果或敏感信息。" };
+  });
+
+  ctx.tools.register(defineTool({
     name: "ssh_list",
     description: "List currently open SSH connections and identify the active server. This reports only live connection metadata (name, host, port, username and active state); it never lists saved SSH resources or credentials. Use it only when the user asks which server is connected. For normal server work, ssh_exec/ssh_read/ssh_write already target the active connection automatically.",
     parameters: {},


### PR DESCRIPTION
### 问题/动机
共享 SSH 面板和 Agent 需要在不暴露终端内容或凭据的前提下查看会话元数据，并按游标读取受限窗口的终端 journal。

### 改动点
- 新增 `ssh_session_list`：低敏会话元数据、来源、存活状态和 journal 游标。
- 新增 `ssh_session_read`：默认 32KiB、最大 128KiB、after 游标、截断/hasMore 状态。
- 独立 reader 不消费 UI journal；读取工具保留审批门。
- 同步更新工具 descriptors/schema 与 terminal journal 生命周期。

### 测试证据
- 上游 `npm install` + `npm test`：39 tests passed / 0 failed。
- journal 窗口、cursor clamp、截断、approval hook 和 descriptor schema 均有覆盖。

### 兼容性说明
新增 Agent 工具，不改变既有 SSH/SFTP/terminal 工具；只提交 `src/`，lib bundle 由上游构建生成。

### 后续提案
危险 DDL 审批通道涉及新的产品权限语义，建议另行讨论后再决定是否纳入上游。