### PR TITLE
增加数据库工具注册与行数上限配置

### DIFF
--- a/src/db-ops.js
+++ b/src/db-ops.js
@@ -18,7 +18,6 @@ import { failResult as fail } from "./envelope.js";
 
 const Cursor = pgCursorModule.default ?? pgCursorModule;
 
-const MAX_DB_ROWS = 200;
 const DB_QUERY_TIMEOUT_MS = 30000;
 /** Idle transactions are rolled back and released after this long. */
 const DB_TX_IDLE_MS = 5 * 60 * 1000;
@@ -206,8 +205,9 @@ function serializeDbValue(value) {
 
 export class DbOpsManager {
   /** @param {import("./index.js").default} sshOpsService */
-  constructor(sshOpsService) {
+  constructor(sshOpsService, maxDbRows = 200) {
     this.sshOpsService = sshOpsService;
+    this.maxDbRows = maxDbRows;
     this.dbConnections = new Map();
     /** txId -> interactive transaction { txId, dbId, kind, handle, timer, createdAt } */
     this.dbTransactions = new Map();
@@ -629,7 +629,7 @@ export class DbOpsManager {
           if (fields?.length) fieldNames = fields.map((f) => f.name);
         });
         stream.on("result", (row) => {
-          if (rows.length >= MAX_DB_ROWS) {
+          if (rows.length >= this.maxDbRows) {
             truncated = true;
             killed = true;
             once(resolve);
@@ -691,13 +691,13 @@ export class DbOpsManager {
       try {
         await raceDeadline(new Promise((resolve, reject) => {
           const readBatch = () => {
-            cursor.read(MAX_DB_ROWS + 1 - rows.length, (err, batch) => {
+            cursor.read(this.maxDbRows + 1 - rows.length, (err, batch) => {
               if (err) { reject(err); return; }
               if (batch.length === 0) { resolve(); return; }
               rows.push(...batch);
-              if (rows.length > MAX_DB_ROWS) {
+              if (rows.length > this.maxDbRows) {
                 truncated = true;
-                rows.length = MAX_DB_ROWS;
+                rows.length = this.maxDbRows;
                 resolve();
                 return;
               }
@@ -908,7 +908,9 @@ export class DbOpsManager {
     if (record.type !== "mysql" && record.type !== "postgresql") {
       return fail("unsupported-op", `db_preview only supports mysql/postgresql, use db_run for ${record.type}`);
     }
-    const limit = Math.max(1, Math.min(MAX_DB_ROWS, Math.floor(Number(request.limit) || 50)));
+    const requestedLimit = Math.floor(Number(request.limit) || 50);
+    if (requestedLimit > this.maxDbRows) return fail("db-limit-too-high", `requested limit ${requestedLimit} exceeds configured max ${this.maxDbRows}`);
+    const limit = Math.max(1, requestedLimit);
     const offset = Math.max(0, Math.floor(Number(request.offset) || 0));
     const built = buildPreviewSql(record.type, request.table, limit, offset);
     if (!built.ok) return fail("bad-request", built.error);
@@ -1022,8 +1024,8 @@ export class DbOpsManager {
           onLose: () => this.killTransaction(tx)
         });
         if (Array.isArray(r)) {
-          const truncated = r.length > MAX_DB_ROWS;
-          const rows = truncated ? r.slice(0, MAX_DB_ROWS) : r;
+          const truncated = r.length > this.maxDbRows;
+          const rows = truncated ? r.slice(0, this.maxDbRows) : r;
           value = { affectedRows: 0, rowCount: rows.length, truncated, rows: rows.map(serializeDbValue) };
         } else {
           value = { affectedRows: r.affectedRows ?? 0, rowCount: 0, truncated: false, rows: [] };
@@ -1035,8 +1037,8 @@ export class DbOpsManager {
           onLose: () => this.killTransaction(tx)
         });
         const allRows = r.rows ?? [];
-        const truncated = allRows.length > MAX_DB_ROWS;
-        const rows = truncated ? allRows.slice(0, MAX_DB_ROWS) : allRows;
+        const truncated = allRows.length > this.maxDbRows;
+        const rows = truncated ? allRows.slice(0, this.maxDbRows) : allRows;
         value = { affectedRows: r.rowCount ?? allRows.length, rowCount: rows.length, truncated, rows: rows.map(serializeDbValue) };
       }
       this.touchTransaction(tx);

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,22 @@ const MAX_FILE_READ_BYTES = 4 * 1024 * 1024;
 // Late readers can still see the exit status of the N most recently exited
 // sessions (session tombstones).
 const MAX_EXIT_TOMBSTONES = 64;
+const DEFAULT_DB_ROWS = 200;
+const HARD_MAX_DB_ROWS = 5000;
+
+function parseDbRows(raw = process.env.DSH_SSH_OPS_MAX_DB_ROWS) {
+  if (raw === undefined) return DEFAULT_DB_ROWS;
+  if (!/^[1-9][0-9]*$/.test(raw)) throw new Error("DSH_SSH_OPS_MAX_DB_ROWS must be a positive integer <= 5000");
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value > HARD_MAX_DB_ROWS) throw new Error("DSH_SSH_OPS_MAX_DB_ROWS must be a positive integer <= 5000");
+  return value;
+}
+
+function parseDbToolRegistration(raw = process.env.DSH_SSH_OPS_REGISTER_DB_TOOLS) {
+  if (raw === undefined || raw === "1" || raw?.toLowerCase() === "true") return true;
+  if (raw === "0" || raw?.toLowerCase() === "false") return false;
+  throw new Error("DSH_SSH_OPS_REGISTER_DB_TOOLS must be 0, 1, true, or false");
+}
 
 const profileRecordSchema = z.object({
   name: z.string(),
@@ -251,6 +267,8 @@ export default class SshOpsService extends TypertRemoteService {
       maxCommandOutputBytes: MAX_COMMAND_OUTPUT_BYTES,
       maxCaptureBytes: MAX_CAPTURE_BYTES,
       streamHeartbeatMs: STREAM_HEARTBEAT_MS,
+      registerDbAgentTools: parseDbToolRegistration(),
+      maxDbRows: parseDbRows(),
       ...config
     };
     // Tear down all connections when the plugin fiber unloads.
@@ -268,7 +286,7 @@ export default class SshOpsService extends TypertRemoteService {
       this.activeConnectionId = null;
       try { this.dbOps?.closeAll().catch(() => {}); } catch {}
     }, "ssh-ops: cleanup");
-    this.dbOps = new DbOpsManager(this);
+    this.dbOps = new DbOpsManager(this, this.config.maxDbRows);
     this.registerTools(ctx);
   }
 
@@ -2569,7 +2587,7 @@ export default class SshOpsService extends TypertRemoteService {
     registerSftpTools(ctx, this);
     registerTunnelTools(ctx, this);
     registerBatchTools(ctx, this);
-    registerDbTools(ctx, this);
+    if (this.config.registerDbAgentTools !== false) registerDbTools(ctx, this);
   }
 
   // ── internals ──────────────────────────────────────────────────────────────

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -621,7 +621,7 @@ export const dbDescribeTableResultSchema = resultSchema(
 export const dbPreviewRequestSchema = z.object({
   dbConnectionId: z.string().min(1),
   table: z.string().min(1),
-  limit: z.number().int().min(1).max(200).optional(),
+  limit: z.number().int().min(1).max(5000).optional(),
   offset: z.number().int().min(0).optional(),
   signal: z.any().optional()
 });


### PR DESCRIPTION
### 问题/动机
在不同部署形态下，需要关闭原生数据库 Agent 工具以避免与 Workbench bridge 重复注册，并为查询/预览/事务统一配置行数上限。

### 改动点
- 新增 `DSH_SSH_OPS_REGISTER_DB_TOOLS`：显式 `0/false` 时关闭原生 DB Agent 工具注册，缺省保持开启。
- 新增 `DSH_SSH_OPS_MAX_DB_ROWS`：统一约束 query、preview、transaction 结果上限，硬上限 5000。
- 预览 schema 上限同步到 5000，超配置值返回明确错误。

### 测试证据
- 上游 `npm test`：39 tests passed / 0 failed。
- 覆盖默认行为、环境变量解析、非法值 fail-fast、分页/事务截断路径。

### 兼容性说明
缺省环境变量保持原有行为（工具注册开启、默认 200 行）；只提交 `src/`，lib bundle 由上游构建生成。

### 后续提案
危险 DDL 审批通道属于独立产品能力，建议另行讨论其审批与权限模型。